### PR TITLE
fix: uninitialized constant JSON (NameError)

### DIFF
--- a/tagger.rb
+++ b/tagger.rb
@@ -1,3 +1,4 @@
+require 'json'
 require 'logger'
 require 'restclient'
 require 'time'


### PR DESCRIPTION
Please forgive my ignorance this my first time I'm using ruby in need to tag some stories on Tracker :)

In ruby 2.5.1 after setup I got run-time error:
```
$ ruby tagger.rb
Traceback (most recent call last):
	2: from tagger.rb:26:in `<main>'
	1: from tagger.rb:26:in `times'
tagger.rb:28:in `block in <main>': uninitialized constant JSON (NameError)
```

and uncle Google said I need to require json :smiley: